### PR TITLE
set content length headers

### DIFF
--- a/src/mirage/mirage.ml
+++ b/src/mirage/mirage.ml
@@ -75,6 +75,8 @@ let wrap_handler_httpaf _user's_error_handler user's_dream_handler =
            2. Upon failure to establish a WebSocket, the function is called to
               transmit the resulting error response. *)
         let forward_response response =
+          Message.set_content_length_headers response;
+
           let headers =
             Httpaf.Headers.of_list (Message.all_headers response) in
 


### PR DESCRIPTION
not sure why this is not present in mirage.

I'm also not sure how mirage.io sets these headers.